### PR TITLE
Remove unused viewTh

### DIFF
--- a/web/src/Leaderboard.elm
+++ b/web/src/Leaderboard.elm
@@ -268,9 +268,6 @@ type alias Row =
     }
 
 
-viewTh : String -> Html.Html Msg
-viewTh s =
-    Html.th [ class "text-left font-medium px-2 py-1", Html.Events.onClick (Sort CheckpointDisplay) ] [ Html.text s ]
 
 
 viewRow : Row -> Html.Html Msg


### PR DESCRIPTION
## Summary
- remove unused `viewTh` function

## Testing
- `just test` *(fails: `just: command not found`)*
- `pytest -q` *(fails: `pytest: command not found`)*