### PR TITLE
Remove unused Elm import

### DIFF
--- a/web/src/Leaderboard.elm
+++ b/web/src/Leaderboard.elm
@@ -8,7 +8,6 @@ import Html.Attributes exposing (class)
 import Html.Events
 import Http
 import Json.Decode as D
-import Set
 import Time
 
 


### PR DESCRIPTION
## Summary
- trim `import Set` from `Leaderboard.elm`

## Testing
- `uv run pytest -q` *(fails: URLError: [Errno 113] No route to host)*